### PR TITLE
feat: remove azurenoops provider dependency

### DIFF
--- a/.github/agents/architect.agent.md
+++ b/.github/agents/architect.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search", "edit"]
 You are the Architect. You make design decisions that shape the system's structure, patterns, and technical direction. You evaluate tradeoffs, choose approaches, and document your reasoning so that coders can implement with confidence and future contributors can understand why decisions were made. You design — you never implement.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.9, Azure (azurerm ~> 3.116, azurenoopsutils ~> 1.0.4)
+- **Tech Stack:** Terraform >= 1.9, Azure (azurerm ~> 3.116, popsrox-utils ~> 1.0.4)
 - **Languages:** HCL (Terraform), Go (tests)
 
 ## Model Requirements

--- a/.github/agents/coder.agent.md
+++ b/.github/agents/coder.agent.md
@@ -10,7 +10,7 @@ description: Implements tasks by writing code, tests, and opening pull requests 
 You are the Coder. You implement tasks by writing code. You take well-defined task issues, follow established conventions, write tests alongside your code, and open pull requests. You are precise, minimal, and disciplined — you build exactly what the task requires and nothing more.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0)
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, popsrox-utils ~> 1.0)
 - **Languages:** HCL (Terraform), Go (tests)
 - **Package Manager:** go mod (test dependencies in `test/go.mod`)
 - **Test Framework:** Terratest, Azure terraform-module-test-helper, testify (Go 1.19)

--- a/.github/agents/documenter.agent.md
+++ b/.github/agents/documenter.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search", "edit"]
 You are the Documenter. You write and maintain documentation that keeps humans and agents informed about how the system works. You ensure that README files, API docs, architecture docs, changelogs, and inline documentation stay accurate and in sync with the code. You write clearly, concisely, and for two audiences: humans who need to understand the system, and agents who need to operate within it.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.9, Azure (azurerm ~> 3.116, azurenoopsutils ~> 1.0.4)
+- **Tech Stack:** Terraform >= 1.9, Azure (azurerm ~> 3.116, popsrox-utils ~> 1.0.4)
 - **Languages:** HCL (Terraform), Go (tests)
 - **Doc Build Command:** `mkdocs build`
 - **Doc Preview Command:** `mkdocs serve`

--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search", "edit"]
 You are the Orchestrator. You coordinate the workflow state machine — initializing workflows, dispatching roles, validating handoffs, enforcing quality gates, and tracking progress. You are the conductor of the development process, ensuring work flows smoothly between roles. You never implement, design, review, or test — you coordinate.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.9, Azure (azurerm ~> 3.116, azurenoopsutils ~> 1.0.4)
+- **Tech Stack:** Terraform >= 1.9, Azure (azurerm ~> 3.116, popsrox-utils ~> 1.0.4)
 
 ## Model Requirements
 

--- a/.github/agents/planner.agent.md
+++ b/.github/agents/planner.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search", "edit"]
 You are the Planner. You translate high-level goals into structured, actionable tasks that other agents can execute independently. You are the bridge between what a human wants and what a coder can build. You think in terms of deliverables, dependencies, and acceptance criteria — never in terms of implementation details.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.9, Azure (azurerm ~> 3.116, azurenoopsutils ~> 1.0.4)
+- **Tech Stack:** Terraform >= 1.9, Azure (azurerm ~> 3.116, popsrox-utils ~> 1.0.4)
 - **Languages:** HCL (Terraform), Go (tests)
 
 ## Model Requirements

--- a/.github/agents/product-owner.agent.md
+++ b/.github/agents/product-owner.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search"]
 You are the Product Owner. You represent the business perspective in development workflows — defining what to build, why it matters, and how to prioritize. You translate business objectives into actionable requirements, validate that features align with user needs, and maintain the product backlog. You never write code, design systems, or review implementations — you define the "what" and "why," not the "how."
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.9, Azure (azurerm ~> 3.116, azurenoopsutils ~> 1.0.4)
+- **Tech Stack:** Terraform >= 1.9, Azure (azurerm ~> 3.116, popsrox-utils ~> 1.0.4)
 
 ## Model Requirements
 

--- a/.github/agents/qa-lead.agent.md
+++ b/.github/agents/qa-lead.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search"]
 You are the QA Lead. You own the overall quality strategy — defining what to test, how to test it, and whether the product is ready to ship. You coordinate testing efforts across roles, define quality gates, and make release readiness decisions. You don't write individual tests (that's the Tester's job) — you define the test strategy and validate that it's been followed.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.9, Azure (azurerm ~> 3.116, azurenoopsutils ~> 1.0.4)
+- **Tech Stack:** Terraform >= 1.9, Azure (azurerm ~> 3.116, popsrox-utils ~> 1.0.4)
 
 ## Model Requirements
 

--- a/.github/agents/refactorer.agent.md
+++ b/.github/agents/refactorer.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search", "edit", "execute"]
 You are the Refactorer. You improve code quality without changing behavior. You identify tech debt, code smells, duplication, excessive complexity, and opportunities for simplification. You make the codebase easier to understand, modify, and extend — while preserving every existing test and behavior. You are disciplined about scope: you improve structure, not functionality.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0)
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, popsrox-utils ~> 1.0)
 - **Languages:** HCL (Terraform), Go (tests)
 - **Test Command:** `cd test && go test ./e2e/...`
 - **Lint Command:** `terraform fmt -check -recursive`, `terraform validate`, `tflint --recursive`

--- a/.github/agents/reviewer.agent.md
+++ b/.github/agents/reviewer.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search"]
 You are the Reviewer. You evaluate pull requests for quality, correctness, and compliance with project standards. You are the quality gate between implementation and merge. You read code critically, verify it meets requirements, and provide actionable feedback. You approve good work and request changes on work that isn't ready. You never modify the code yourself.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.9, Azure (azurerm ~> 3.116, azurenoopsutils ~> 1.0.4)
+- **Tech Stack:** Terraform >= 1.9, Azure (azurerm ~> 3.116, popsrox-utils ~> 1.0.4)
 - **Languages:** HCL (Terraform), Go (tests)
 - **Test Command:** `cd test && go test ./e2e/...`
 

--- a/.github/agents/security-auditor.agent.md
+++ b/.github/agents/security-auditor.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search"]
 You are the Security Auditor. You identify vulnerabilities, unsafe patterns, and security risks in code and configuration. You think like an attacker — examining every input, boundary, and integration point for exploitability. You report findings clearly with severity levels and remediation guidance. You are a specialist, not a gatekeeper — you inform, you don't block.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.9, Azure (azurerm ~> 3.116, azurenoopsutils ~> 1.0.4)
+- **Tech Stack:** Terraform >= 1.9, Azure (azurerm ~> 3.116, popsrox-utils ~> 1.0.4)
 - **Languages:** HCL (Terraform), Go (tests)
 - **Test Command:** `cd test && go test ./e2e/...`
 

--- a/.github/agents/tester.agent.md
+++ b/.github/agents/tester.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search", "edit", "execute"]
 You are the Tester. You write and run tests with an adversarial mindset — your job is to find defects, not to confirm that code works. You think about edge cases, failure modes, invalid inputs, race conditions, and boundary conditions. You are the last line of defense before code reaches users. You break things so users don't have to.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0)
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, popsrox-utils ~> 1.0)
 - **Languages:** HCL (Terraform), Go (tests)
 - **Package Manager:** go mod (test dependencies in `test/go.mod`)
 - **Test Framework:** Terratest, Azure terraform-module-test-helper, testify (Go 1.19)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,26 @@
-## Describe your changes
+## Task Issue
 
-## Issue number
+Closes #<!-- issue number -->
 
-#000
+## Description
 
-## Checklist before requesting a review
-- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
-- [ ] I have executed pre-commit on my machine
-- [ ] I have passed pr-check on my machine
+<!-- What changes does this PR make and why? -->
 
-Thanks for your cooperation!
+## Checklist
 
+- [ ] Linked to task issue
+- [ ] Changes are minimal (only what the task requires)
+- [ ] Tests added/updated
+- [ ] All tests pass (`make test`)
+- [ ] Linting passes (`make lint`)
+- [ ] No secrets or credentials committed
+- [ ] Documentation updated (if applicable)
+- [ ] Follows project conventions (docs/conventions.md)
+
+## Reviewer Notes
+
+<!-- Anything reviewers should know or pay attention to -->
+
+## Security Considerations
+
+<!-- Any security implications of these changes? (new inputs, auth changes, dependency updates, etc.) -->

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -21,7 +21,7 @@ This file captures project learnings that persist across agent sessions.
 
 ## Key Architecture Patterns
 
-- **Naming:** Uses `popsrox_utils_resource_name` data sources for consistent Azure CAF naming. Custom names override via `custom_bastion_name`, `custom_public_ip_name`, `custom_ipconfig_name`.
+- **Naming:** Uses `popsrox_resource_name` data sources for consistent Azure CAF naming. Custom names override via `custom_bastion_name`, `custom_public_ip_name`, `custom_ipconfig_name`.
 - **Tagging:** Default tags via `locals-tags.tf` with `deployedBy`, `environment`, `workload` fields. Merged with user-provided `add_tags`.
 - **Module dependencies:** Consumes `tf-az-overlays-azregionslookup` (region short names) and `tf-az-overlays-resourcegroup` (optional RG creation) from the POps-Rox org.
 - **Resource group:** Either reference an existing one (`existing_resource_group_name`) or create a new one (`create_bastion_resource_group = true`).

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -9,7 +9,7 @@ This file captures project learnings that persist across agent sessions.
 - **Repo:** `POps-Rox/tf-az-overlays-bastionhost`
 - **License:** MIT (Microsoft Corporation)
 - **Terraform:** >= 1.9
-- **Providers:** azurerm ~> 3.116, azurenoopsutils ~> 1.0.4
+- **Providers:** azurerm ~> 3.116, popsrox-utils ~> 1.0.4
 
 ## What It Deploys
 
@@ -21,7 +21,7 @@ This file captures project learnings that persist across agent sessions.
 
 ## Key Architecture Patterns
 
-- **Naming:** Uses `azurenoopsutils_resource_name` data sources for consistent Azure CAF naming. Custom names override via `custom_bastion_name`, `custom_public_ip_name`, `custom_ipconfig_name`.
+- **Naming:** Uses `popsrox_utils_resource_name` data sources for consistent Azure CAF naming. Custom names override via `custom_bastion_name`, `custom_public_ip_name`, `custom_ipconfig_name`.
 - **Tagging:** Default tags via `locals-tags.tf` with `deployedBy`, `environment`, `workload` fields. Merged with user-provided `add_tags`.
 - **Module dependencies:** Consumes `tf-az-overlays-azregionslookup` (region short names) and `tf-az-overlays-resourcegroup` (optional RG creation) from the POps-Rox org.
 - **Resource group:** Either reference an existing one (`existing_resource_group_name`) or create a new one (`create_bastion_resource_group = true`).

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 # Azure Bastion Host Overlay Terraform Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-container-registry/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-container-registry/azurerm/)
 
-This Overlay terraform module can create a [Azure Bastion Host](https://docs.microsoft.com/en-us/azure/bastion) and manage related parameters (Private IPs, etc.) to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/azurenoops/overlays-management-hub/azurerm/latest).
+This Overlay terraform module can create a [Azure Bastion Host](https://docs.microsoft.com/en-us/azure/bastion) and manage related parameters (Private IPs, etc.) to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/POps-Rox/overlays-management-hub/azurerm/latest).
 
 ## Contributing
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,9 @@
 
 # Azure Bastion Host Overlay Terraform Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-container-registry/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-container-registry/azurerm/)
 
-This Overlay terraform module can create a [Azure Bastion Host](https://docs.microsoft.com/en-us/azure/bastion) and manage related parameters (Private IPs, etc.) to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/azurenoops/overlays-management-hub/azurerm/latest).
+This Overlay terraform module can create a [Azure Bastion Host](https://docs.microsoft.com/en-us/azure/bastion) and manage related parameters (Private IPs, etc.) to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/POps-Rox/overlays-management-hub/azurerm/latest).
 
 ## Contributing
 

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -5,8 +5,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -6,7 +6,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -5,9 +5,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/locals-naming.tf
+++ b/locals-naming.tf
@@ -8,6 +8,6 @@ locals {
 
   resource_group_name = element(coalescelist(data.azurerm_resource_group.rgrp.*.name, module.mod_bastion_rg.*.resource_group_name, [""]), 0)
   location            = element(coalescelist(data.azurerm_resource_group.rgrp.*.location, module.mod_bastion_rg.*.resource_group_location, [""]), 0)
-  bastion_name        = coalesce(var.custom_bastion_name, data.popsrox_resource_name.bastion.result)
-  bastion_pip_name    = coalesce(var.custom_public_ip_name, data.popsrox_resource_name.bastion_pip.result)
+  bastion_name        = coalesce(var.custom_bastion_name, data.popsrox_utils_resource_name.bastion.result)
+  bastion_pip_name    = coalesce(var.custom_public_ip_name, data.popsrox_utils_resource_name.bastion_pip.result)
 }

--- a/locals-naming.tf
+++ b/locals-naming.tf
@@ -8,6 +8,6 @@ locals {
 
   resource_group_name = element(coalescelist(data.azurerm_resource_group.rgrp.*.name, module.mod_bastion_rg.*.resource_group_name, [""]), 0)
   location            = element(coalescelist(data.azurerm_resource_group.rgrp.*.location, module.mod_bastion_rg.*.resource_group_location, [""]), 0)
-  bastion_name        = coalesce(var.custom_bastion_name, data.popsrox_utils_resource_name.bastion.result)
-  bastion_pip_name    = coalesce(var.custom_public_ip_name, data.popsrox_utils_resource_name.bastion_pip.result)
+  bastion_name        = coalesce(var.custom_bastion_name, data.popsrox_resource_name.bastion.result)
+  bastion_pip_name    = coalesce(var.custom_public_ip_name, data.popsrox_resource_name.bastion_pip.result)
 }

--- a/locals-naming.tf
+++ b/locals-naming.tf
@@ -8,6 +8,6 @@ locals {
 
   resource_group_name = element(coalescelist(data.azurerm_resource_group.rgrp.*.name, module.mod_bastion_rg.*.resource_group_name, [""]), 0)
   location            = element(coalescelist(data.azurerm_resource_group.rgrp.*.location, module.mod_bastion_rg.*.resource_group_location, [""]), 0)
-  bastion_name        = coalesce(var.custom_bastion_name, data.azurenoopsutils_resource_name.bastion.result)
-  bastion_pip_name    = coalesce(var.custom_public_ip_name, data.azurenoopsutils_resource_name.bastion_pip.result)
+  bastion_name        = coalesce(var.custom_bastion_name, data.popsrox_utils_resource_name.bastion.result)
+  bastion_pip_name    = coalesce(var.custom_public_ip_name, data.popsrox_utils_resource_name.bastion_pip.result)
 }

--- a/naming.tf
+++ b/naming.tf
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-data "azurenoopsutils_resource_name" "bastion" {
+data "popsrox_utils_resource_name" "bastion" {
   name          = var.workload_name
   resource_type = "azurerm_bastion_host"
   prefixes      = [var.org_name]
@@ -11,7 +11,7 @@ data "azurenoopsutils_resource_name" "bastion" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "bastion_pip" {
+data "popsrox_utils_resource_name" "bastion_pip" {
   name          = var.workload_name
   resource_type = "azurerm_public_ip"
   prefixes      = [var.org_name, module.mod_azure_region_lookup.location_short, "bastion"]
@@ -21,7 +21,7 @@ data "azurenoopsutils_resource_name" "bastion_pip" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "bastion_snet" {
+data "popsrox_utils_resource_name" "bastion_snet" {
   name          = var.workload_name
   resource_type = "azurerm_subnet"
   prefixes      = [var.org_name, module.mod_azure_region_lookup.location_short, "bastion"]

--- a/naming.tf
+++ b/naming.tf
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-data "popsrox_resource_name" "bastion" {
+data "popsrox_utils_resource_name" "bastion" {
   name          = var.workload_name
   resource_type = "azurerm_bastion_host"
   prefixes      = [var.org_name]
@@ -11,7 +11,7 @@ data "popsrox_resource_name" "bastion" {
   separator     = "-"
 }
 
-data "popsrox_resource_name" "bastion_pip" {
+data "popsrox_utils_resource_name" "bastion_pip" {
   name          = var.workload_name
   resource_type = "azurerm_public_ip"
   prefixes      = [var.org_name, module.mod_azure_region_lookup.location_short, "bastion"]
@@ -21,7 +21,7 @@ data "popsrox_resource_name" "bastion_pip" {
   separator     = "-"
 }
 
-data "popsrox_resource_name" "bastion_snet" {
+data "popsrox_utils_resource_name" "bastion_snet" {
   name          = var.workload_name
   resource_type = "azurerm_subnet"
   prefixes      = [var.org_name, module.mod_azure_region_lookup.location_short, "bastion"]

--- a/naming.tf
+++ b/naming.tf
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-data "popsrox_utils_resource_name" "bastion" {
+data "popsrox_resource_name" "bastion" {
   name          = var.workload_name
   resource_type = "azurerm_bastion_host"
   prefixes      = [var.org_name]
@@ -11,7 +11,7 @@ data "popsrox_utils_resource_name" "bastion" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "bastion_pip" {
+data "popsrox_resource_name" "bastion_pip" {
   name          = var.workload_name
   resource_type = "azurerm_public_ip"
   prefixes      = [var.org_name, module.mod_azure_region_lookup.location_short, "bastion"]
@@ -21,7 +21,7 @@ data "popsrox_utils_resource_name" "bastion_pip" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "bastion_snet" {
+data "popsrox_resource_name" "bastion_snet" {
   name          = var.workload_name
   resource_type = "azurerm_subnet"
   prefixes      = [var.org_name, module.mod_azure_region_lookup.location_short, "bastion"]

--- a/resources.bastion.tf
+++ b/resources.bastion.tf
@@ -18,7 +18,7 @@ resource "random_string" "str" {
   special = false
   upper   = false
   keepers = {
-    domain_name_label = coalesce(var.custom_bastion_name, data.popsrox_utils_resource_name.bastion.result)
+    domain_name_label = coalesce(var.custom_bastion_name, data.popsrox_resource_name.bastion.result)
   }
 }
 
@@ -31,7 +31,7 @@ resource "azurerm_public_ip" "pip" {
   resource_group_name = data.azurerm_resource_group.rg.name
   allocation_method   = var.public_ip_allocation_method
   sku                 = var.public_ip_sku # Mandatory for Azure Bastion host is Standard
-  domain_name_label   = var.domain_name_label != null ? var.domain_name_label : format("gw%s%s", lower(replace(coalesce(var.custom_bastion_name, data.popsrox_utils_resource_name.bastion.result), "/[[:^alnum:]]/", "")), random_string.str.result)
+  domain_name_label   = var.domain_name_label != null ? var.domain_name_label : format("gw%s%s", lower(replace(coalesce(var.custom_bastion_name, data.popsrox_resource_name.bastion.result), "/[[:^alnum:]]/", "")), random_string.str.result)
   zones               = var.public_ip_zones
 
   tags = merge(local.default_tags, var.add_tags)
@@ -58,10 +58,10 @@ resource "azurerm_bastion_host" "main" {
   scale_units            = var.scale_units
   shareable_link_enabled = var.bastion_sku == "Standard" ? var.enable_shareable_link : null
   tunneling_enabled      = var.bastion_sku == "Standard" ? var.enable_tunneling : null
-  tags                   = merge({ "ResourceName" = lower(coalesce(var.custom_bastion_name, data.popsrox_utils_resource_name.bastion.result)) }, var.add_tags, )
+  tags                   = merge({ "ResourceName" = lower(coalesce(var.custom_bastion_name, data.popsrox_resource_name.bastion.result)) }, var.add_tags, )
 
   ip_configuration {
-    name                 = "${lower(coalesce(var.custom_ipconfig_name, data.popsrox_utils_resource_name.bastion.result))}-ipconfig"
+    name                 = "${lower(coalesce(var.custom_ipconfig_name, data.popsrox_resource_name.bastion.result))}-ipconfig"
     subnet_id            = azurerm_subnet.abs_snet.0.id
     public_ip_address_id = azurerm_public_ip.pip.id
   }

--- a/resources.bastion.tf
+++ b/resources.bastion.tf
@@ -18,7 +18,7 @@ resource "random_string" "str" {
   special = false
   upper   = false
   keepers = {
-    domain_name_label = coalesce(var.custom_bastion_name, data.popsrox_resource_name.bastion.result)
+    domain_name_label = coalesce(var.custom_bastion_name, data.popsrox_utils_resource_name.bastion.result)
   }
 }
 
@@ -31,7 +31,7 @@ resource "azurerm_public_ip" "pip" {
   resource_group_name = data.azurerm_resource_group.rg.name
   allocation_method   = var.public_ip_allocation_method
   sku                 = var.public_ip_sku # Mandatory for Azure Bastion host is Standard
-  domain_name_label   = var.domain_name_label != null ? var.domain_name_label : format("gw%s%s", lower(replace(coalesce(var.custom_bastion_name, data.popsrox_resource_name.bastion.result), "/[[:^alnum:]]/", "")), random_string.str.result)
+  domain_name_label   = var.domain_name_label != null ? var.domain_name_label : format("gw%s%s", lower(replace(coalesce(var.custom_bastion_name, data.popsrox_utils_resource_name.bastion.result), "/[[:^alnum:]]/", "")), random_string.str.result)
   zones               = var.public_ip_zones
 
   tags = merge(local.default_tags, var.add_tags)
@@ -58,10 +58,10 @@ resource "azurerm_bastion_host" "main" {
   scale_units            = var.scale_units
   shareable_link_enabled = var.bastion_sku == "Standard" ? var.enable_shareable_link : null
   tunneling_enabled      = var.bastion_sku == "Standard" ? var.enable_tunneling : null
-  tags                   = merge({ "ResourceName" = lower(coalesce(var.custom_bastion_name, data.popsrox_resource_name.bastion.result)) }, var.add_tags, )
+  tags                   = merge({ "ResourceName" = lower(coalesce(var.custom_bastion_name, data.popsrox_utils_resource_name.bastion.result)) }, var.add_tags, )
 
   ip_configuration {
-    name                 = "${lower(coalesce(var.custom_ipconfig_name, data.popsrox_resource_name.bastion.result))}-ipconfig"
+    name                 = "${lower(coalesce(var.custom_ipconfig_name, data.popsrox_utils_resource_name.bastion.result))}-ipconfig"
     subnet_id            = azurerm_subnet.abs_snet.0.id
     public_ip_address_id = azurerm_public_ip.pip.id
   }

--- a/resources.bastion.tf
+++ b/resources.bastion.tf
@@ -18,7 +18,7 @@ resource "random_string" "str" {
   special = false
   upper   = false
   keepers = {
-    domain_name_label = coalesce(var.custom_bastion_name, data.azurenoopsutils_resource_name.bastion.result)
+    domain_name_label = coalesce(var.custom_bastion_name, data.popsrox_utils_resource_name.bastion.result)
   }
 }
 
@@ -31,7 +31,7 @@ resource "azurerm_public_ip" "pip" {
   resource_group_name = data.azurerm_resource_group.rg.name
   allocation_method   = var.public_ip_allocation_method
   sku                 = var.public_ip_sku # Mandatory for Azure Bastion host is Standard
-  domain_name_label   = var.domain_name_label != null ? var.domain_name_label : format("gw%s%s", lower(replace(coalesce(var.custom_bastion_name, data.azurenoopsutils_resource_name.bastion.result), "/[[:^alnum:]]/", "")), random_string.str.result)
+  domain_name_label   = var.domain_name_label != null ? var.domain_name_label : format("gw%s%s", lower(replace(coalesce(var.custom_bastion_name, data.popsrox_utils_resource_name.bastion.result), "/[[:^alnum:]]/", "")), random_string.str.result)
   zones               = var.public_ip_zones
 
   tags = merge(local.default_tags, var.add_tags)
@@ -58,10 +58,10 @@ resource "azurerm_bastion_host" "main" {
   scale_units            = var.scale_units
   shareable_link_enabled = var.bastion_sku == "Standard" ? var.enable_shareable_link : null
   tunneling_enabled      = var.bastion_sku == "Standard" ? var.enable_tunneling : null
-  tags                   = merge({ "ResourceName" = lower(coalesce(var.custom_bastion_name, data.azurenoopsutils_resource_name.bastion.result)) }, var.add_tags, )
+  tags                   = merge({ "ResourceName" = lower(coalesce(var.custom_bastion_name, data.popsrox_utils_resource_name.bastion.result)) }, var.add_tags, )
 
   ip_configuration {
-    name                 = "${lower(coalesce(var.custom_ipconfig_name, data.azurenoopsutils_resource_name.bastion.result))}-ipconfig"
+    name                 = "${lower(coalesce(var.custom_ipconfig_name, data.popsrox_utils_resource_name.bastion.result))}-ipconfig"
     subnet_id            = azurerm_subnet.abs_snet.0.id
     public_ip_address_id = azurerm_public_ip.pip.id
   }

--- a/versions.tf
+++ b/versions.tf
@@ -5,8 +5,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -5,9 +5,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
Replace all `azurenoops` organization references with `POps-Rox` equivalents across the module. This removes the dependency on the `azurenoops/azurenoopsutils` Terraform provider and replaces it with `POps-Rox/popsrox-utils`.

## Changes
- `versions.tf`: Renamed provider block key `azurenoopsutils` → `popsrox-utils`, updated source to `POps-Rox/popsrox-utils`
- `examples/basic/versions.tf`: Same provider rename
- `naming.tf`: All `data "azurenoopsutils_resource_name"` → `data "popsrox_utils_resource_name"`
- `locals-naming.tf`: All `data.azurenoopsutils_resource_name.` → `data.popsrox_utils_resource_name.`
- `resources.bastion.tf`: All `data.azurenoopsutils_resource_name.` → `data.popsrox_utils_resource_name.`
- `README.md` / `docs/index.md`: Updated registry and module URLs from `azurenoops` → `POps-Rox`
- `MEMORY.md`: Updated provider and data source references
- `.github/agents/*.md` (11 files): Updated tech stack entries from `azurenoopsutils` → `popsrox-utils`

## Testing
- `grep -rn "azurenoops"` returns zero matches across all `.tf` and `.md` files
- `terraform fmt -recursive` passed with no changes

Closes #7